### PR TITLE
fix(install): add missing scheduler.py and sub_agent_manager.py to do…

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -142,22 +142,26 @@ Write-Host ""
 Write-Host "  [3/6] 下载核心文件" -ForegroundColor White
 Hr
 
-$coreFiles = @("agent.py","bot.py","main.py","tools_builtin.py","requirements.txt","update.sh","update.ps1","hydrabot","hydrabot.bat","VERSION")
+$coreFiles = @("agent.py","bot.py","main.py","tools_builtin.py","scheduler.py","sub_agent_manager.py","requirements.txt","hydrabot","hydrabot.bat","VERSION")
+$scriptFiles = @("scripts/update.sh","scripts/update.ps1","scripts/start.sh")
 $failed = @()
-foreach ($f in $coreFiles) {
+
+# Create directories first
+New-Item -ItemType Directory -Force -Path "$INSTALL_DIR\tools"      | Out-Null
+New-Item -ItemType Directory -Force -Path "$INSTALL_DIR\mcp_servers" | Out-Null
+New-Item -ItemType Directory -Force -Path "$INSTALL_DIR\scripts"     | Out-Null
+
+foreach ($f in ($coreFiles + $scriptFiles)) {
     Write-Host "  $($f.PadRight(30))" -NoNewline
+    $dest = "$INSTALL_DIR\$($f -replace '/','\\')"
     try {
-        Invoke-WebRequest -Uri "$REPO/$f" -OutFile "$INSTALL_DIR\$f" -UseBasicParsing
+        Invoke-WebRequest -Uri "$REPO/$f" -OutFile $dest -UseBasicParsing
         Write-Host "OK" -ForegroundColor Green
     } catch {
         Write-Host "SKIP (keep old)" -ForegroundColor Yellow
         $failed += $f
     }
 }
-
-# Create directories
-New-Item -ItemType Directory -Force -Path "$INSTALL_DIR\tools"      | Out-Null
-New-Item -ItemType Directory -Force -Path "$INSTALL_DIR\mcp_servers" | Out-Null
 
 if ($failed.Count -gt 0) {
     Warn "以下文件下载失败: $($failed -join ', ')"

--- a/install.sh
+++ b/install.sh
@@ -276,7 +276,7 @@ echo ""
 # [3/6]  下载核心文件
 # ══════════════════════════════════════════════════════════════
 step "[3/6] 下载核心文件"
-CORE_FILES=(agent.py bot.py main.py tools_builtin.py requirements.txt scripts/update.sh hydrabot VERSION)
+CORE_FILES=(agent.py bot.py main.py tools_builtin.py scheduler.py sub_agent_manager.py requirements.txt scripts/update.sh hydrabot VERSION)
 FAILED_DL=()
 for f in "${CORE_FILES[@]}"; do
     printf "  %-28s " "$f"


### PR DESCRIPTION
…wnload lists

Both install.ps1 and install.sh were missing scheduler.py and sub_agent_manager.py from their core file lists, causing ModuleNotFoundError on first run.

Also fixes install.ps1: update.sh and update.ps1 now download from their correct scripts/ subdirectory path, and creates the scripts/ directory before downloading.