### PR TITLE
fix & feat: venv python fix, bug fixes, SOUL.md persona system

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -182,7 +182,6 @@ class AgentPool:
         Each unique (chat_id, thread_id) gets its own isolated conversation history.
         """
         model_idx = self.user_model.get(session_id, 0)
-        client = self.get_client(model_idx)
 
         if session_id not in self.conversations:
             self.conversations[session_id] = []
@@ -194,6 +193,7 @@ class AgentPool:
         session_tools = self._session_tools(session_id)
 
         try:
+            client = self.get_client(model_idx)
             if client.provider == "anthropic":
                 response = self._anthropic_loop(client, list(history), session_tools, session_id)
             else:
@@ -628,6 +628,17 @@ class AgentPool:
     # System prompt
     # ─────────────────────────────────────────────
 
+    def _load_soul(self) -> str:
+        """Load SOUL.md persona file. Returns empty string if not set."""
+        soul_file = Path("SOUL.md")
+        if not soul_file.exists():
+            return ""
+        try:
+            content = soul_file.read_text(encoding="utf-8").strip()
+            return content
+        except Exception:
+            return ""
+
     def _system_prompt(self, user_id) -> str:
         tool_list = (
             ", ".join(sorted(self.tools.keys()))
@@ -654,7 +665,10 @@ class AgentPool:
             for i, m in enumerate(self.model_configs)
         )
 
-        return f"""你是 HydraBot，一个强大的本地 AI 助手，通过 Telegram 与用户交互，运行在用户的机器上。你像九头蛇一样能不断长出新的能力——每当用户需要新功能，你就能自己创建工具来满足需求。
+        soul = self._load_soul()
+        soul_section = f"\n## 人設與個性風格（SOUL.md）\n{soul}\n" if soul else ""
+
+        return f"""你是 HydraBot，一个强大的本地 AI 助手，通过 Telegram 与用户交互，运行在用户的机器上。你像九头蛇一样能不断长出新的能力——每当用户需要新功能，你就能自己创建工具来满足需求。{soul_section}
 
 ## 当前使用
 {cur_info}

--- a/bot.py
+++ b/bot.py
@@ -195,6 +195,7 @@ class TelegramBot:
             "/tasks — 查看背景任務與進度\n"
             "/notify — 查看/管理定時通知排程\n"
             "/timezone — 查看/修改時區設定\n"
+            "/soul — 查看/清除 Bot 人設\n"
             "/status — 系统状态\n\n"
             + (f"**子代理 Bot 管理**\n{agent_cmds}\n" if agent_cmds else "")
             + "⏰ **定時通知**\n"
@@ -317,6 +318,43 @@ class TelegramBot:
                     f"修改: `/timezone UTC+8`",
                     parse_mode="Markdown",
                 )
+
+    async def cmd_soul(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """
+        /soul        — 顯示目前人設（SOUL.md）
+        /soul clear  — 清除人設
+        """
+        if not self._ok(update.effective_user.id):
+            return
+        from pathlib import Path
+        soul_file = Path(__file__).parent / "SOUL.md"
+        args = context.args
+
+        if args and args[0].lower() == "clear":
+            if soul_file.exists():
+                soul_file.unlink()
+                await update.message.reply_text("✅ 人設已清除（SOUL.md 已刪除）")
+            else:
+                await update.message.reply_text("📝 目前沒有人設可清除")
+            return
+
+        if not soul_file.exists():
+            await update.message.reply_text(
+                "📝 **SOUL.md 尚未設定**\n\n"
+                "你可以直接告訴我你想要的人設風格，例如：\n"
+                "「幫我設定人設：你是一隻傲嬌的貓娘，說話帶點嬌氣...」\n\n"
+                "或手動編輯 `SOUL.md` 放在安裝目錄中。\n"
+                "修改後立即生效，無需重啟。",
+                parse_mode="Markdown",
+            )
+            return
+
+        content = soul_file.read_text(encoding="utf-8").strip()
+        if not content:
+            await update.message.reply_text("📝 SOUL.md 存在但內容為空")
+            return
+
+        await self._send(update, f"📝 **目前人設 (SOUL.md)**\n\n{content}")
 
     async def cmd_status(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         if not self._ok(update.effective_user.id):
@@ -733,18 +771,15 @@ class TelegramBot:
             import requests
             from pathlib import Path
 
-            # Fetch latest VERSION from GitHub
             url = "https://raw.githubusercontent.com/Adaimade/HydraBot/main/VERSION"
-            response = requests.get(url, timeout=3)
+            # Run blocking network call in thread pool to avoid blocking the event loop
+            response = await asyncio.to_thread(requests.get, url, timeout=3)
             response.raise_for_status()
             latest = response.text.strip()
 
-            # Read local version
             version_file = Path(__file__).parent / "VERSION"
             if version_file.exists():
                 current = version_file.read_text().strip()
-
-                # Compare versions
                 if latest != current:
                     print(f"\n⚠️  新版本可用！({current} → {latest})")
                     print(f"   运行以下命令更新:")
@@ -781,6 +816,7 @@ class TelegramBot:
             BotCommand("notify",       "查看/管理定時通知排程"),
             BotCommand("timezone",     "查看/設定時區 (UTC+N)"),
             BotCommand("status",       "系统状态与会话信息"),
+            BotCommand("soul",         "查看/清除 Bot 人設（SOUL.md）"),
         ]
         if self.sub_agents is not None:
             commands += [
@@ -808,6 +844,7 @@ class TelegramBot:
         app.add_handler(CommandHandler("notify",       self.cmd_notify))
         app.add_handler(CommandHandler("timezone",     self.cmd_timezone))
         app.add_handler(CommandHandler("status",       self.cmd_status))
+        app.add_handler(CommandHandler("soul",         self.cmd_soul))
         if self.sub_agents is not None:
             app.add_handler(CommandHandler("new_agent",    self.cmd_new_agent))
             app.add_handler(CommandHandler("list_agents",  self.cmd_list_agents))
@@ -816,14 +853,25 @@ class TelegramBot:
             MessageHandler(filters.TEXT & ~filters.COMMAND, self.handle_message)
         )
 
-        auth_info = (
-            f"{len(self.authorized_users)} 个授权用户"
-            if self.authorized_users else "所有人（无限制）"
-        )
+        import datetime
+        local_tz_offset = datetime.datetime.now().astimezone().utcoffset()
+        tz_seconds = int(local_tz_offset.total_seconds())
+        tz_hours   = tz_seconds // 3600
+        tz_sign    = "+" if tz_hours >= 0 else ""
+        local_tz_str = f"UTC{tz_sign}{tz_hours}"
+
+        if self.authorized_users:
+            auth_info = f"{len(self.authorized_users)} 个 (IDs: {', '.join(str(u) for u in sorted(self.authorized_users))})"
+        else:
+            auth_info = "所有人（无限制）"
+
         print(f"🐍 HydraBot running!")
         print(f"   Models  : {len(self.pool.model_configs)} 组")
-        print(f"   Tools   : {len(self.pool.tools) + 1} 个")
+        for i, m in enumerate(self.pool.model_configs):
+            print(f"     [{i}] {m.get('name', m['model'])}  ({m['provider']} / {m['model']})")
+        print(f"   Tools   : {len(self.pool.tools) + 4} 个")
         print(f"   Access  : {auth_info}")
+        print(f"   Timezone: {local_tz_str}（本机系统时区）")
         print(f"   Session : chat_id + thread_id 双维度隔离")
         print(f"   Ctrl+C to stop\n")
 

--- a/hydrabot.bat
+++ b/hydrabot.bat
@@ -8,8 +8,14 @@ setlocal enabledelayedexpansion
 set "SCRIPT_DIR=%~dp0"
 cd /d "%SCRIPT_DIR%"
 
-REM ── Find Python ───────────────────────────────────────────────
+REM ── Find Python (prefer venv) ─────────────────────────────────
 set "PYTHON="
+REM Use venv Python directly if available (avoids missing-package issues)
+if exist "%SCRIPT_DIR%venv\Scripts\python.exe" (
+    set "PYTHON=%SCRIPT_DIR%venv\Scripts\python.exe"
+    goto :found_python
+)
+REM Fall back to system Python
 for %%A in (python python3) do (
     where %%A >nul 2>&1
     if !errorlevel! equ 0 (
@@ -19,12 +25,6 @@ for %%A in (python python3) do (
 )
 
 :found_python
-if defined PYTHON (
-    REM Try to activate venv
-    if exist "venv\Scripts\activate.bat" (
-        call venv\Scripts\activate.bat
-    )
-)
 
 REM ── Read version ──────────────────────────────────────────────
 set "VER=?"

--- a/tools_builtin.py
+++ b/tools_builtin.py
@@ -103,7 +103,8 @@ def get_builtin_tools(agent: "Agent") -> list:
         try:
             p = Path(path)
             p.parent.mkdir(parents=True, exist_ok=True)
-            p.open(mode, encoding="utf-8").write(content)
+            with p.open(mode, encoding="utf-8") as f:
+                f.write(content)
             return f"✅ 已写入 {path}（{p.stat().st_size:,} bytes）"
         except Exception as e:
             return f"❌ {e}"
@@ -268,13 +269,24 @@ def get_builtin_tools(agent: "Agent") -> list:
         """Start an MCP server process and register its tools."""
         try:
             import shlex
-            args = shlex.split(command)
+            if sys.platform == "win32":
+                # shlex.split posix=True treats backslash as escape char,
+                # breaking Windows paths like "mcp_servers\server.py".
+                # Normalize to forward slashes first (Python accepts / on Windows),
+                # then parse with posix=False to avoid further escape processing.
+                normalized = command.replace("\\", "/")
+                args = shlex.split(normalized, posix=False)
+                # posix=False leaves surrounding quotes in tokens; strip them
+                args = [a.strip('"').strip("'") for a in args]
+            else:
+                args = shlex.split(command)
             proc = subprocess.Popen(
                 args,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                encoding="utf-8",
                 bufsize=1,
             )
         except FileNotFoundError:
@@ -380,6 +392,33 @@ def get_builtin_tools(agent: "Agent") -> list:
             return f"❓ 未找到: `{key}`"
 
         return f"❌ 未知操作: {action}（支持: set / get / list / delete）"
+
+    # ─────────────────────────────────────────────────────────────
+    # edit_soul
+    # ─────────────────────────────────────────────────────────────
+
+    def edit_soul(content: str = None, action: str = "get") -> str:
+        """Read or write the bot's persona file (SOUL.md)."""
+        soul_file = Path("SOUL.md")
+
+        if action == "get":
+            if not soul_file.exists():
+                return "📝 SOUL.md 尚未建立（目前沒有人設）\n使用 action='set' 並提供 content 來設定人設。"
+            text = soul_file.read_text(encoding="utf-8").strip()
+            return f"📝 **當前人設 (SOUL.md)**\n\n{text}" if text else "📝 SOUL.md 存在但內容為空"
+
+        elif action == "set":
+            if not content:
+                return "❌ 需要提供 content 參數"
+            soul_file.write_text(content.strip(), encoding="utf-8")
+            return "✅ 人設已更新（SOUL.md），下次對話即時生效，無需重啟"
+
+        elif action == "clear":
+            if soul_file.exists():
+                soul_file.unlink()
+            return "✅ 人設已清除（SOUL.md 已刪除）"
+
+        return f"❌ 未知操作: {action}（支持: get / set / clear）"
 
     # ─────────────────────────────────────────────────────────────
     # Schemas
@@ -571,4 +610,25 @@ def get_builtin_tools(agent: "Agent") -> list:
                 "required": ["key", "action"],
             },
         }, remember),
+
+        ("edit_soul", {
+            "name": "edit_soul",
+            "description": (
+                "讀取或更新 Bot 的人設檔案（SOUL.md）。\n"
+                "SOUL.md 的內容會自動注入到每次對話的 system prompt 最前面，\n"
+                "讓 Bot 以指定的個性、風格、語氣與用戶互動。\n"
+                "修改後立即生效，無需重啟。\n"
+                "action='get'   → 顯示目前人設內容\n"
+                "action='set'   → 設定新的人設（覆蓋整個檔案）\n"
+                "action='clear' → 清除人設，恢復預設行為"
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "action":  {"type": "string", "description": "操作: get / set / clear", "enum": ["get", "set", "clear"]},
+                    "content": {"type": "string", "description": "人設內容（Markdown 格式，action=set 時必填）"},
+                },
+                "required": ["action"],
+            },
+        }, edit_soul),
     ]


### PR DESCRIPTION
Fixes:
- fix(hydrabot.bat): prefer venv python.exe over system Python to resolve 'pip install openai' ImportError on Windows startup
- fix(tools_builtin): close file handle in write_file using context manager
- fix(bot): correct tool count display from +1 to +4 in startup log
- fix(bot): use asyncio.to_thread for _check_updates to avoid blocking event loop
- fix(agent): move get_client() inside try/except in chat() so ImportErrors produce proper error messages
- fix(tools_builtin): handle Windows backslash paths in mcp_connect; add explicit utf-8 encoding to subprocess Popen

Features:
- feat(bot): show authorized user IDs, per-model details, and local system timezone in startup log
- feat(agent/tools/bot): add SOUL.md persona system — users can set a custom personality via edit_soul tool or /soul command; injected into system prompt on every turn with immediate hot-reload