### PR TITLE
fix & feat: bug fixes, thread safety, whitelist command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > An AI assistant running on your local machine. Chat with it through Telegram to execute code, manage files, spawn parallel sub-agents, and even create new tools at runtime to expand its own capabilities — just like a hydra: cut off one head and more grow back.
 
 [![Version](https://img.shields.io/badge/version-1.2.0-blue)](VERSION)
-[![Python](https://img.shields.io/badge/python-3.9%2B-blue)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
 [中文文件](README.zh-TW.md)
@@ -15,7 +15,7 @@
 
 | Feature | Description |
 |---------|-------------|
-| 🤖 **Multi-Model Support** | Configure up to 3 AI models simultaneously (primary + fast + backup), switchable mid-conversation |
+| 🤖 **Multi-Model Support** | Configure multiple AI models simultaneously (primary + fast + backup), switchable mid-conversation |
 | ⚡ **Parallel Sub-Agents** | `spawn_agent` — delegate subtasks to other models, running in parallel without blocking |
 | 🔧 **Self-Expansion** | `create_tool` — the LLM can write and hot-reload new tools at runtime |
 | 💻 **Local Execution** | Python / Shell code runs directly on your machine with full filesystem access |
@@ -37,7 +37,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/Adaimade/HydraBot/main/insta
 ```
 
 The installer will automatically:
-1. Detect and install Python 3.9+
+1. Detect and install Python 3.10+
 2. Clone / download core files
 3. Create a Python virtual environment and install dependencies
 4. Interactively prompt for your Telegram Token and AI API Key
@@ -159,6 +159,7 @@ Copy `config.example.json` and modify:
 | `/tasks` | View background task progress |
 | `/notify` | List scheduled notifications; `/notify cancel <id>` to cancel |
 | `/timezone` | View current timezone; `/timezone UTC+8` to set |
+| `/whitelist` | Manage the authorized users list; `/whitelist add <id>` to add, `/whitelist remove <id>` to remove |
 | `/status` | Show system status (version, timezone, models, tool count, schedule count, etc.) |
 | `/new_agent` | Start the wizard to create a new sub-agent Bot |
 | `/list_agents` | List all registered sub-agent Bots and their status |
@@ -363,6 +364,29 @@ def get_tools():
 
 ---
 
+## Bot Persona (SOUL.md)
+
+You can give the bot a custom personality, tone, and behavior style by creating a `SOUL.md` file. Its content is automatically injected at the top of every conversation's system prompt — **changes take effect immediately without restarting**.
+
+**Usage (just tell the bot in conversation):**
+
+```
+View current persona:   Ask the bot "show me the current persona"
+Set a new persona:      Ask the bot "set the persona to: ...(describe the style you want)"
+Clear the persona:      Ask the bot "clear the persona and restore default behavior"
+```
+
+The bot will call the `edit_soul` tool to handle these operations.
+
+**Example SOUL.md:**
+
+```markdown
+You are a witty and humorous assistant. You speak concisely and love using metaphors
+to explain complex concepts. You end every reply with a short, on-topic joke.
+```
+
+---
+
 ## Multi-Project Isolation
 
 Each **Telegram group** or **Topic** has completely independent:
@@ -388,7 +412,7 @@ Downloads the latest core files without affecting user data (`config.json`, `too
 
 ## System Requirements
 
-- Python 3.9+
+- Python 3.10+
 - Telegram Bot Token ([@BotFather](https://t.me/BotFather))
 - API Key from at least one AI Provider
 - Internet connection

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -4,7 +4,7 @@
 > 運行在你本地機器上的 AI 助手，透過 Telegram 與之對話，能執行程式碼、管理檔案、並行派出子代理，甚至在執行時自行建立新工具來擴展自身能力——就像九頭蛇一樣，砍掉一頭會再長出更多。
 
 [![Version](https://img.shields.io/badge/version-1.2.0-blue)](VERSION)
-[![Python](https://img.shields.io/badge/python-3.9%2B-blue)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
 [English](README.md)
@@ -15,7 +15,7 @@
 
 | 功能 | 說明 |
 |------|------|
-| 🤖 **多模型並存** | 同時配置最多 3 組 AI 模型，主力 + 快速 + 備用，對話中可即時切換 |
+| 🤖 **多模型並存** | 同時配置多組 AI 模型，主力 + 快速 + 備用，對話中可即時切換 |
 | ⚡ **並行子代理** | `spawn_agent` — 把子任務派給其他模型，後台並行執行，互不阻塞 |
 | 🔧 **自我擴展** | `create_tool` — LLM 可在運行時自行撰寫並熱載入新工具 |
 | 💻 **本地執行** | Python / Shell 程式碼直接跑在你的機器上，可讀寫本地檔案 |
@@ -37,7 +37,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/Adaimade/HydraBot/main/insta
 ```
 
 安裝器會自動完成：
-1. 檢測並安裝 Python 3.9+
+1. 檢測並安裝 Python 3.10+
 2. 克隆/下載核心檔案
 3. 建立 Python 虛擬環境並安裝依賴
 4. 互動式填寫 Telegram Token、AI API Key
@@ -159,6 +159,7 @@ hydrabot help           # 顯示完整幫助
 | `/tasks` | 查看背景任務進度 |
 | `/notify` | 列出當前會話的定時排程；`/notify cancel <id>` 取消 |
 | `/timezone` | 查看當前時區設定；`/timezone UTC+8` 設定時區 |
+| `/whitelist` | 管理授權用戶白名單；`/whitelist add <id>` 新增，`/whitelist remove <id>` 移除 |
 | `/status` | 顯示系統狀態（版本、時區、模型、工具數、排程數等） |
 | `/new_agent` | 啟動精靈，建立新的子代理 Bot |
 | `/list_agents` | 查看所有子代理 Bot 及其狀態 |
@@ -363,6 +364,29 @@ def get_tools():
 
 ---
 
+## Bot 人設（SOUL.md）
+
+你可以替 Bot 設定個性、口吻與行為風格，儲存在 `SOUL.md` 檔案中。內容會自動注入到每次對話的 system prompt 最前面，**修改後立即生效，無需重啟**。
+
+**使用方式（對話中直接下指令）：**
+
+```
+查看目前人設：  告訴 Bot「顯示目前的人設」
+設定新人設：    告訴 Bot「把人設設定為：...（描述你想要的個性）」
+清除人設：      告訴 Bot「清除人設，恢復預設行為」
+```
+
+Bot 會呼叫 `edit_soul` 工具完成操作。
+
+**SOUL.md 範例：**
+
+```markdown
+你是一個幽默風趣的助理，說話簡潔有力，擅長用比喻解釋複雜概念。
+你習慣在回覆結尾加上一個貼近主題的小笑話。
+```
+
+---
+
 ## 多專案隔離
 
 每個 **Telegram 群組** 或 **Topic（話題）** 擁有完全獨立的：
@@ -388,7 +412,7 @@ hydrabot update
 
 ## 系統需求
 
-- Python 3.9+
+- Python 3.10+
 - Telegram Bot Token（[@BotFather](https://t.me/BotFather)）
 - 至少一個 AI Provider 的 API Key
 - 網路連接

--- a/agent.py
+++ b/agent.py
@@ -18,6 +18,9 @@ from typing import Any
 from scheduler import NotificationScheduler, parse_fire_at, REPEAT_INTERVALS
 
 
+# Maximum number of tool-call iterations per agent loop turn
+MAX_TOOL_CALLS = 30
+
 # ─────────────────────────────────────────────────────────────
 # Internal single-model client
 # ─────────────────────────────────────────────────────────────
@@ -80,7 +83,7 @@ class _ModelClient:
 
 class AgentPool:
     """
-    Manages 3 model configurations, a shared tool registry,
+    Manages multiple model configurations, a shared tool registry,
     and background sub-agent task execution.
 
     Drop-in replacement for the old Agent class.
@@ -111,6 +114,7 @@ class AgentPool:
 
         # Sub-agent task tracking  { task_id -> info_dict }
         self.running_tasks: dict[str, dict] = {}
+        self._tasks_lock = threading.Lock()  # guards running_tasks
 
         # Persistent Python namespace for execute_python
         self._py_ns: dict = {"__builtins__": __builtins__}
@@ -238,7 +242,8 @@ class AgentPool:
             if m.get("description"):
                 lines.append(f"      {m['description']}")
             lines.append("")
-        lines.append(f"切换命令: `/model 0`  `/model 1`  `/model 2`")
+        switch_examples = "  ".join(f"`/model {i}`" for i in range(len(self.model_configs)))
+        lines.append(f"切换命令: {switch_examples}")
         return "\n".join(lines)
 
     # ─────────────────────────────────────────────
@@ -257,15 +262,16 @@ class AgentPool:
         task_id = f"sub_{uuid.uuid4().hex[:6]}"
         display_name = name.strip() if name and name.strip() else task_id
 
-        self.running_tasks[task_id] = {
-            "id": task_id,
-            "name": display_name,
-            "task": task[:60] + ("…" if len(task) > 60 else ""),
-            "model": client.name,
-            "model_idx": model_index,
-            "status": "running",
-            "session_id": session_id,
-        }
+        with self._tasks_lock:
+            self.running_tasks[task_id] = {
+                "id": task_id,
+                "name": display_name,
+                "task": task[:60] + ("…" if len(task) > 60 else ""),
+                "model": client.name,
+                "model_idx": model_index,
+                "status": "running",
+                "session_id": session_id,
+            }
 
         pool = self
 
@@ -284,7 +290,8 @@ class AgentPool:
                 # Inject a session-bound report_progress tool so the LLM can
                 # push intermediate updates without waiting for task completion.
                 def report_progress(message: str) -> str:
-                    pool.running_tasks[task_id]["progress"] = message
+                    with pool._tasks_lock:
+                        pool.running_tasks[task_id]["progress"] = message
                     _push(
                         f"📊 **{display_name}** 進度更新\n"
                         f"模型: {client.name} | `{task_id}`\n\n"
@@ -325,14 +332,16 @@ class AgentPool:
                         session_id=None,
                     )
 
-                pool.running_tasks[task_id]["status"] = "done"
+                with pool._tasks_lock:
+                    pool.running_tasks[task_id]["status"] = "done"
                 msg = (
                     f"🤖 **{display_name}** 已完成\n"
                     f"模型: {client.name} | `{task_id}`\n\n"
                     f"{result}"
                 )
             except Exception as e:
-                pool.running_tasks[task_id]["status"] = "error"
+                with pool._tasks_lock:
+                    pool.running_tasks[task_id]["status"] = "error"
                 msg = (
                     f"❌ **{display_name}** 執行失敗\n"
                     f"模型: {client.name} | `{task_id}`\n"
@@ -352,10 +361,12 @@ class AgentPool:
         )
 
     def list_tasks_info(self) -> str:
-        if not self.running_tasks:
+        with self._tasks_lock:
+            tasks_snapshot = dict(self.running_tasks)
+        if not tasks_snapshot:
             return "📋 目前沒有子代理任務記錄"
-        lines = [f"📋 **子代理任務** （{len(self.running_tasks)} 筆）\n"]
-        for t in sorted(self.running_tasks.values(), key=lambda x: x["id"], reverse=True)[:10]:
+        lines = [f"📋 **子代理任務** （{len(tasks_snapshot)} 筆）\n"]
+        for t in sorted(tasks_snapshot.values(), key=lambda x: x["id"], reverse=True)[:10]:
             emoji = {"running": "⏳", "done": "✅", "error": "❌"}.get(t["status"], "❓")
             name = t.get("name", t["id"])
             # Show name prominently; show task_id in parentheses only if name differs
@@ -550,7 +561,7 @@ class AgentPool:
         system = self._system_prompt(user_id)
         schemas = self._get_schemas(tools_dict)
 
-        for _ in range(30):
+        for _ in range(MAX_TOOL_CALLS):
             resp = client.client.messages.create(
                 model=client.model,
                 max_tokens=client.max_tokens,
@@ -594,7 +605,7 @@ class AgentPool:
             },
         } for s in schemas]
 
-        for _ in range(30):
+        for _ in range(MAX_TOOL_CALLS):
             kwargs: dict = {
                 "model": client.model,
                 "messages": messages,

--- a/bot.py
+++ b/bot.py
@@ -4,6 +4,7 @@ Telegram bot interface for HydraBot.
 """
 
 import asyncio
+import json
 import logging
 import platform
 import re
@@ -106,6 +107,19 @@ class TelegramBot:
             return True
         return user_id in self.authorized_users
 
+    def _save_whitelist(self):
+        """Persist authorized_users back to config.json (CWD-relative)."""
+        config_path = Path("config.json")
+        try:
+            data = json.loads(config_path.read_text(encoding="utf-8-sig"))
+            data["authorized_users"] = sorted(self.authorized_users)
+            config_path.write_text(
+                json.dumps(data, indent=2, ensure_ascii=False),
+                encoding="utf-8",
+            )
+        except Exception as e:
+            print(f"⚠️ Failed to save whitelist to config.json: {e}")
+
     # ─────────────────────────────────────────────
     # Timezone helpers
     # ─────────────────────────────────────────────
@@ -183,10 +197,12 @@ class TelegramBot:
             "/delete_agent — 刪除子代理\n"
         ) if self.sub_agents is not None else ""
 
+        uid = update.effective_user.id
         text = (
             f"👋 你好，{name}！我是 HydraBot 🐍\n\n"
             f"运行在你的机器上，配备 **{n} 组模型** + **{len(self.pool.tools) + 4} 个工具**。\n"
             "可以执行代码、管理文件、派出背景任務——还能创建新工具来扩展自己！\n\n"
+            f"🪪 你的 Telegram ID: `{uid}`\n\n"
             "**一般指令**\n"
             "/start — 显示此消息\n"
             "/reset — 清除当前对话历史\n"
@@ -196,6 +212,7 @@ class TelegramBot:
             "/notify — 查看/管理定時通知排程\n"
             "/timezone — 查看/修改時區設定\n"
             "/soul — 查看/清除 Bot 人設\n"
+            "/whitelist — 管理授權用戶白名單\n"
             "/status — 系统状态\n\n"
             + (f"**子代理 Bot 管理**\n{agent_cmds}\n" if agent_cmds else "")
             + "⏰ **定時通知**\n"
@@ -398,6 +415,93 @@ class TelegramBot:
             f"定時排程: `{active_notifs}` 個"
         )
         await update.message.reply_text(text, parse_mode="Markdown")
+
+    async def cmd_whitelist(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """
+        /whitelist              — show authorized users
+        /whitelist add <id>     — add user to whitelist
+        /whitelist remove <id>  — remove user from whitelist
+        """
+        if not self._ok(update.effective_user.id):
+            return
+
+        args = context.args
+
+        if not args:
+            if not self.authorized_users:
+                await update.message.reply_text(
+                    "🔓 **白名單為空** — 目前所有人均可使用此 Bot\n\n"
+                    "新增第一位授權用戶後，未授權用戶將無法使用。\n\n"
+                    "新增用戶: `/whitelist add <user_id>`\n"
+                    "💡 用戶可用 `/start` 查看自己的 ID，或透過 @userinfobot 取得。",
+                    parse_mode="Markdown",
+                )
+            else:
+                ids = "\n".join(f"• `{uid}`" for uid in sorted(self.authorized_users))
+                await update.message.reply_text(
+                    f"👥 **授權用戶白名單** ({len(self.authorized_users)} 人)\n\n"
+                    f"{ids}\n\n"
+                    f"新增: `/whitelist add <user_id>`\n"
+                    f"移除: `/whitelist remove <user_id>`",
+                    parse_mode="Markdown",
+                )
+            return
+
+        sub = args[0].lower()
+
+        if sub in ("add", "remove") and len(args) >= 2:
+            try:
+                uid = int(args[1])
+            except ValueError:
+                await update.message.reply_text(
+                    "❌ 用戶 ID 必須是數字，例如 `/whitelist add 123456789`",
+                    parse_mode="Markdown",
+                )
+                return
+
+            if sub == "add":
+                if uid in self.authorized_users:
+                    await update.message.reply_text(
+                        f"⚠️ 用戶 `{uid}` 已在白名單中", parse_mode="Markdown"
+                    )
+                    return
+                self.authorized_users.add(uid)
+                self._save_whitelist()
+                await update.message.reply_text(
+                    f"✅ 已新增用戶 `{uid}` 到白名單\n"
+                    f"白名單現有 {len(self.authorized_users)} 人",
+                    parse_mode="Markdown",
+                )
+            else:  # remove
+                if uid not in self.authorized_users:
+                    await update.message.reply_text(
+                        f"❌ 用戶 `{uid}` 不在白名單中", parse_mode="Markdown"
+                    )
+                    return
+                self.authorized_users.discard(uid)
+                self._save_whitelist()
+                if self.authorized_users:
+                    await update.message.reply_text(
+                        f"✅ 已從白名單移除用戶 `{uid}`\n"
+                        f"白名單現有 {len(self.authorized_users)} 人",
+                        parse_mode="Markdown",
+                    )
+                else:
+                    await update.message.reply_text(
+                        f"✅ 已從白名單移除用戶 `{uid}`\n\n"
+                        f"⚠️ 白名單現在為空，**所有人均可使用此 Bot**。",
+                        parse_mode="Markdown",
+                    )
+        else:
+            await update.message.reply_text(
+                "**白名單管理指令**\n\n"
+                "`/whitelist`              — 查看當前白名單\n"
+                "`/whitelist add <id>`     — 新增授權用戶\n"
+                "`/whitelist remove <id>`  — 移除授權用戶\n\n"
+                "💡 用戶可傳送 `/start` 查看自己的 Telegram ID，"
+                "或使用 @userinfobot 取得 ID。",
+                parse_mode="Markdown",
+            )
 
     # ─────────────────────────────────────────────
     # Sub-agent bot management commands
@@ -817,6 +921,7 @@ class TelegramBot:
             BotCommand("timezone",     "查看/設定時區 (UTC+N)"),
             BotCommand("status",       "系统状态与会话信息"),
             BotCommand("soul",         "查看/清除 Bot 人設（SOUL.md）"),
+            BotCommand("whitelist",    "管理授權用戶白名單"),
         ]
         if self.sub_agents is not None:
             commands += [
@@ -845,6 +950,7 @@ class TelegramBot:
         app.add_handler(CommandHandler("timezone",     self.cmd_timezone))
         app.add_handler(CommandHandler("status",       self.cmd_status))
         app.add_handler(CommandHandler("soul",         self.cmd_soul))
+        app.add_handler(CommandHandler("whitelist",    self.cmd_whitelist))
         if self.sub_agents is not None:
             app.add_handler(CommandHandler("new_agent",    self.cmd_new_agent))
             app.add_handler(CommandHandler("list_agents",  self.cmd_list_agents))

--- a/install.ps1
+++ b/install.ps1
@@ -113,7 +113,7 @@ function Find-Python {
         try {
             $v = & $cmd --version 2>&1
             if ($v -match "Python 3\.(\d+)") {
-                if ([int]$Matches[1] -ge 9) { return $cmd }
+                if ([int]$Matches[1] -ge 10) { return $cmd }
             }
         } catch {}
     }
@@ -122,7 +122,7 @@ function Find-Python {
 
 $PYTHON = Find-Python
 if (-not $PYTHON) {
-    Warn "未找到 Python 3.9+，尝试用 winget 自动安装..."
+    Warn "未找到 Python 3.10+，尝试用 winget 自动安装..."
     try {
         winget install -e --id Python.Python.3.12 --silent --accept-source-agreements --accept-package-agreements
         $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")

--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ cat << 'BANNER'
         |___/
 BANNER
 printf "${NC}"
-REMOTE_VER=$(curl -fsSL "$REPO/VERSION" 2>/dev/null | tr -d '[:space:]') || REMOTE_VER="1.1.0"
+REMOTE_VER=$(curl -fsSL --max-time 10 "$REPO/VERSION" 2>/dev/null | tr -d '[:space:]') || REMOTE_VER="1.1.0"
 printf "${BOLD}  Self-expanding AI Assistant via Telegram  ${G}v${REMOTE_VER}${NC}\n"
 printf "${DIM}  https://github.com/Adaimade/HydraBot${NC}\n\n"
 
@@ -87,7 +87,7 @@ python_ok() {
     local major minor
     major=$("$cmd" -c "import sys; print(sys.version_info.major)" 2>/dev/null) || return 1
     minor=$("$cmd" -c "import sys; print(sys.version_info.minor)" 2>/dev/null) || return 1
-    [[ "$major" -ge 3 && "$minor" -ge 9 ]]
+    [[ "$major" -ge 3 && "$minor" -ge 10 ]]
 }
 
 # ── Install curl if missing ────────────────────────────────────
@@ -110,7 +110,7 @@ command -v curl &>/dev/null && ok "curl  $(curl --version | head -1 | awk '{prin
 # ── Install Python ────────────────────────────────────────────
 PYTHON=""
 # Check existing python
-for cmd in python3 python3.12 python3.11 python3.10 python3.9 python; do
+for cmd in python3 python3.13 python3.12 python3.11 python3.10 python; do
     if python_ok "$cmd"; then
         PYTHON="$cmd"
         break
@@ -118,7 +118,7 @@ for cmd in python3 python3.12 python3.11 python3.10 python3.9 python; do
 done
 
 if [[ -z "$PYTHON" ]]; then
-    warn "未找到 Python 3.9+，尝试自动安装..."
+    warn "未找到 Python 3.10+，尝试自动安装..."
     echo ""
 
     case "$OS" in
@@ -200,13 +200,13 @@ if [[ -z "$PYTHON" ]]; then
             ;;
 
         *)
-            printf "\n  ${R}不支持的系统，请手动安装 Python 3.9+：${NC}\n"
+            printf "\n  ${R}不支持的系统，请手动安装 Python 3.10+：${NC}\n"
             printf "  ${C}https://www.python.org/downloads/${NC}\n\n"
             exit 1
             ;;
     esac
 
-    [[ -z "$PYTHON" ]] && err "Python 安装失败，请手动安装 Python 3.9+ 后重试"
+    [[ -z "$PYTHON" ]] && err "Python 安装失败，请手动安装 Python 3.10+ 后重试"
 fi
 
 ok "Python  $($PYTHON --version)  ($PYTHON)"
@@ -280,7 +280,7 @@ CORE_FILES=(agent.py bot.py main.py tools_builtin.py scheduler.py sub_agent_mana
 FAILED_DL=()
 for f in "${CORE_FILES[@]}"; do
     printf "  %-28s " "$f"
-    if curl -fsSL "$REPO/$f" -o "$INSTALL_DIR/$f" 2>/dev/null; then
+    if curl -fsSL --max-time 30 "$REPO/$f" -o "$INSTALL_DIR/$f" 2>/dev/null; then
         printf "${G}✓${NC}\n"
     else
         printf "${Y}⚠ (跳过)${NC}\n"

--- a/scheduler.py
+++ b/scheduler.py
@@ -294,7 +294,10 @@ class NotificationScheduler:
                     if job.active and job.fire_at <= now:
                         to_fire.append(job)
             for job in to_fire:
-                self._fire_job(job)
+                # Re-check active flag: the job may have been cancelled
+                # between the collection above and now.
+                if job.active:
+                    self._fire_job(job)
 
     def _fire_job(self, job: ScheduledJob):
         """觸發一個通知並決定是否重新排程。"""

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -14,7 +14,7 @@ if command -v python3 &>/dev/null; then
 elif command -v python &>/dev/null; then
     PYTHON="python"
 else
-    echo "❌ Python not found! Please install Python 3.9+"
+    echo "❌ Python not found! Please install Python 3.10+"
     exit 1
 fi
 

--- a/sub_agent_manager.py
+++ b/sub_agent_manager.py
@@ -172,12 +172,17 @@ class SubAgentManager:
             return f"找不到 main.py: {main_py}"
 
         try:
-            proc = subprocess.Popen(
-                [sys.executable, str(main_py)],
-                cwd=str(agent_dir),
-                stdout=open(agent_dir / "bot.log", "a"),
-                stderr=subprocess.STDOUT,
-            )
+            log_fh = open(agent_dir / "bot.log", "a")
+            try:
+                proc = subprocess.Popen(
+                    [sys.executable, str(main_py)],
+                    cwd=str(agent_dir),
+                    stdout=log_fh,
+                    stderr=subprocess.STDOUT,
+                )
+            finally:
+                # The subprocess has inherited the fd; close the Python wrapper.
+                log_fh.close()
             self._procs[name] = proc
             return None
         except Exception as e:

--- a/tools_builtin.py
+++ b/tools_builtin.py
@@ -154,10 +154,20 @@ def get_builtin_tools(agent: "Agent") -> list:
     # create_tool  ← self-expansion core
     # ─────────────────────────────────────────────────────────────
 
+    # Names injected per-session (not in agent.tools) that must not be overwritten
+    _SESSION_TOOL_NAMES = {
+        "spawn_agent", "schedule_notification",
+        "list_notifications", "cancel_notification", "report_progress",
+    }
+
     def create_tool(tool_name: str, tool_code: str) -> str:
         """Write a tool module to tools/ and hot-reload."""
         if not tool_name.replace("_", "").isalnum():
             return "❌ 工具名只能包含字母、数字、下划线"
+
+        # Prevent overwriting built-in or session-bound tools
+        if tool_name in agent.tools or tool_name in _SESSION_TOOL_NAMES:
+            return f"❌ 工具名 `{tool_name}` 與內建工具衝突，請換一個名稱"
 
         tools_dir = Path("tools")
         tools_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
Bug fixes:
- agent.py: add _tasks_lock to guard running_tasks dict against concurrent writes from ThreadPoolExecutor background threads
- sub_agent_manager.py: fix file descriptor leak — close bot.log handle after passing it to Popen
- scheduler.py: fix race condition in _run_loop by re-checking job.active before calling _fire_job
- tools_builtin.py: prevent create_tool from overwriting built-in or session-bound tool names

Improvements:
- agent.py: extract MAX_TOOL_CALLS = 30 constant; fix AgentPool docstring; make model switch hint dynamic
- install.sh / install.ps1 / READMEs / start.sh: raise minimum Python requirement from 3.9 to 3.10 (code uses | union syntax)
- install.sh: add --max-time to curl calls to prevent hangs

New feature:
- bot.py: add /whitelist command to manage authorized_users from Telegram chat (add/remove users, persists to config.json); /start now shows the user's own Telegram ID

Docs:
- README.md / README.zh-TW.md: add SOUL.md persona section, document /whitelist command, fix "up to 3 models" inaccuracy