### PR TITLE
fix(hydrabot): Prioritize venv Python to resolve missing openai module

### DIFF
--- a/hydrabot
+++ b/hydrabot
@@ -22,6 +22,19 @@ activate_venv() {
 }
 
 find_python() {
+    # Prefer venv Python first (like Windows .bat does)
+    if [[ -f "$SCRIPT_DIR/venv/Scripts/python" ]]; then
+        echo "$SCRIPT_DIR/venv/Scripts/python"
+        return
+    elif [[ -f "$SCRIPT_DIR/venv/bin/python" ]]; then
+        echo "$SCRIPT_DIR/venv/bin/python"
+        return
+    elif [[ -f "$SCRIPT_DIR/venv/bin/python3" ]]; then
+        echo "$SCRIPT_DIR/venv/bin/python3"
+        return
+    fi
+
+    # Fall back to system Python
     activate_venv
     for cmd in python3 python; do
         command -v "$cmd" &>/dev/null && { echo "$cmd"; return; }


### PR DESCRIPTION
When users installed HydraBot using any of the three installation methods (PowerShell, Bash, or manual git+venv), the bot would fail with:
  ImportError: No module named 'openai'

Root cause: The find_python() function in the Bash 'hydrabot' launcher was not prioritizing the virtual environment's Python interpreter. Instead, it would activate the venv but then search for system Python, causing it to use a Python without the installed dependencies.

Solution: Modified find_python() to prioritize venv Python first (matching the Windows hydrabot.bat behavior), only falling back to system Python if the venv is not available.

This ensures:
- Virtual environment is used when available
- All dependencies installed via pip are properly accessible
- Consistent behavior across all three installation methods