### PR TITLE
fix(main.py): Set correct working directory at startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,6 +87,12 @@ def load_config() -> dict:
 
 
 def main():
+    # Set working directory to the installation directory (where config.json is)
+    # This ensures relative paths in tools work correctly
+    script_dir = Path(__file__).parent
+    import os
+    os.chdir(script_dir)
+
     # Windows asyncio compatibility
     if sys.platform == "win32":
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())


### PR DESCRIPTION
Fixed issue where tools (like list_files) would fail with path not found errors when HydraBot is launched from different directories.

Root cause: main.py did not set the working directory to the installation directory, causing relative paths to be resolved against the current shell working directory instead of the HydraBot installation directory.

Solution: Set os.chdir() to the script's parent directory at startup, ensuring all tools use correct paths relative to the installation.

This fixes errors like:
  ❌ 路徑不存在: C:\Users\66\Documents\GitHub\HydraBot\tools

Instead correctly resolves to:
  ✅ C:\Users\66\hydrabot\tools